### PR TITLE
NitroBolt coloured argument booleans

### DIFF
--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -949,9 +949,11 @@ const comments = function (colors) {
 };
 
 // eslint-disable-next-line max-len
-const extraTurboWarpBlocks = `
-<block type="argument_reporter_boolean"><field name="VALUE">is compiled?</field></block>
-<block type="argument_reporter_boolean"><field name="VALUE">is NitroBolt?</field></block>
+const nbBlocksColours = `colourmutprimary="#ff5726" colourmutsecondary="#e64f23" colourmuttertiary="#e63e0d" colourmutquaternary="#e63e0d"`;
+// eslint-disable-next-line max-len
+const extraNitroBoltBlocks = `
+<block type="argument_reporter_boolean"><field name="VALUE">is compiled?</field><mutation ${nbBlocksColours}></mutation></block>
+<block type="argument_reporter_boolean"><field name="VALUE">is NitroBolt?</field><mutation ${nbBlocksColours}></mutation></block>
 `;
 /* eslint-enable no-unused-vars */
 
@@ -1006,11 +1008,11 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
     const myBlocksXML = moveCategory('procedures') || myBlocks(isInitialSetup, isStage, targetId, colors.more);
     const commentsXML = moveCategory('comments') || comments(colors.comments);
 
-    // Always display TurboWarp blocks as the first extension, if it exists,
+    // Always display NitroBolt blocks as the first extension, if it exists,
     // and also add an "is compiled?" block to the top.
-    let turbowarpXML = moveCategory('tw');
-    if (turbowarpXML && !turbowarpXML.includes(extraTurboWarpBlocks)) {
-        turbowarpXML = turbowarpXML.replace('<block', `${extraTurboWarpBlocks}<block`);
+    let nitroboltXML = moveCategory('tw'); // legacy id
+    if (nitroboltXML && !nitroboltXML.includes(extraNitroBoltBlocks)) {
+        nitroboltXML = nitroboltXML.replace('<block', `${extraNitroBoltBlocks}<block`);
     }
 
     const everything = [
@@ -1028,8 +1030,8 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
         commentsXML
     ];
 
-    if (turbowarpXML) {
-        everything.push(gap, turbowarpXML);
+    if (nitroboltXML) {
+        everything.push(gap, nitroboltXML);
     }
 
     for (const extensionCategory of categoriesXML) {

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -949,7 +949,7 @@ const comments = function (colors) {
 };
 
 // eslint-disable-next-line max-len
-const nbBlocksColours = `colourmutprimary="#ff5726" colourmutsecondary="#e64f23" colourmuttertiary="#e63e0d" colourmutquaternary="#e63e0d"`;
+const nbBlocksColours = `colourmutprimary="#ff5726" colourmutsecondary="#f34b1a" colourmuttertiary="#e63e0d" colourmutquaternary="#e63e0d"`;
 // eslint-disable-next-line max-len
 const extraNitroBoltBlocks = `
 <block type="argument_reporter_boolean"><field name="VALUE">is compiled?</field><mutation ${nbBlocksColours}></mutation></block>


### PR DESCRIPTION
requires: https://github.com/Nitro-Bolt/scratch-blocks/pull/2/

Nitpicks some branding fixes in lib/make-toolbox-xml.js and implement's NitroBolt coloured argument booleans.