### PR TITLE
Make custom toolbox XML easier for extensions.

### DIFF
--- a/src/containers/blocks.jsx
+++ b/src/containers/blocks.jsx
@@ -123,7 +123,8 @@ class Blocks extends React.Component {
             'onWorkspaceUpdate',
             'onWorkspaceMetricsChange',
             'setBlocks',
-            'setLocale'
+            'setLocale',
+            'onExtensionAPI',
         ]);
         this.ScratchBlocks.prompt = this.handlePromptStart;
         this.ScratchBlocks.statusButtonCallback = this.handleConnectionModalStart;
@@ -372,6 +373,7 @@ class Blocks extends React.Component {
         this.props.vm.addListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
         this.props.vm.addListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
         this.props.vm.addListener('PERIPHERAL_DISCONNECTED', this.handleStatusButtonUpdate);
+        this.props.vm.addListener('CREATE_UNSANDBOXED_EXTENSION_API', this.onExtensionAPI);
     }
     detachVM () {
         this.props.vm.removeListener('SCRIPT_GLOW_ON', this.onScriptGlowOn);
@@ -386,6 +388,12 @@ class Blocks extends React.Component {
         this.props.vm.removeListener('BLOCKSINFO_UPDATE', this.handleBlocksInfoUpdate);
         this.props.vm.removeListener('PERIPHERAL_CONNECTED', this.handleStatusButtonUpdate);
         this.props.vm.removeListener('PERIPHERAL_DISCONNECTED', this.handleStatusButtonUpdate);
+        this.props.vm.removeListener('CREATE_UNSANDBOXED_EXTENSION_API', this.onExtensionAPI);
+    }
+
+    onExtensionAPI(Scratch) {
+      // Assume's the Scratch.gui handle was ran.
+      Scratch.gui.makeToolboxXML = makeToolboxXML;
     }
 
     updateToolboxBlockValue (id, value) {
@@ -455,7 +463,8 @@ class Blocks extends React.Component {
                 this.props.vm.runtime.getBlocksXML(target),
                 this.props.theme
             );
-            return makeToolboxXML(false, target.isStage, target.id, dynamicBlocksXML,
+            return makeToolboxXML(this.props.vm, false, target.isStage,
+                target.id, dynamicBlocksXML,
                 targetCostumes[targetCostumes.length - 1].name,
                 stageCostumes[stageCostumes.length - 1].name,
                 targetSounds.length > 0 ? targetSounds[targetSounds.length - 1].name : '',

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -1056,7 +1056,8 @@ makeToolboxXML.exports = {
   blockSeparator,
   xmlOpen,
   xmlClose,
-  extraTurboWarpBlocks,
+  nbBlocksColours,
+  extraNitroBoltBlocks,
 
   motion,
   looks,

--- a/src/lib/make-toolbox-xml.js
+++ b/src/lib/make-toolbox-xml.js
@@ -959,6 +959,7 @@ const xmlOpen = '<xml style="display: none">';
 const xmlClose = '</xml>';
 
 /**
+ * @param {?VirtualMachine} vm - Virtual machine instance.
  * @param {!boolean} isInitialSetup - Whether the toolbox is for initial setup. If the mode is "initial setup",
  * blocks with localized default parameters (e.g. ask and wait) should not be loaded. (LLK/scratch-gui#5445)
  * @param {?boolean} isStage - Whether the toolbox is for a stage-type target. This is always set to true
@@ -974,7 +975,7 @@ const xmlClose = '</xml>';
  * @param {?object} colors - The colors for the theme.
  * @returns {string} - a ScratchBlocks-style XML document for the contents of the toolbox.
  */
-const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categoriesXML = [],
+const makeToolboxXML = function (vm, isInitialSetup, isStage = true, targetId, categoriesXML = [],
     costumeName = '', backdropName = '', soundName = '', colors = defaultBlockColors) {
     isStage = isInitialSetup || isStage;
     const gap = [categorySeparator];
@@ -1037,7 +1038,35 @@ const makeToolboxXML = function (isInitialSetup, isStage = true, targetId, categ
     }
 
     everything.push(xmlClose);
+    if (vm) vm.emit(
+      'MAKE_TOOLBOX_XML', makeToolboxXML.exports, everything,
+      isInitialSetup, isStage, targetId, categoriesXML,
+      costumeName, backdropName, soundName, colors
+    );
     return everything.join('\n');
+};
+makeToolboxXML.exports = {
+  make: (...args) => makeToolboxXML(...args),
+  translate,
+  xmlEscape,
+
+  categorySeparator,
+  blockSeparator,
+  xmlOpen,
+  xmlClose,
+  extraTurboWarpBlocks,
+
+  motion,
+  looks,
+  sound,
+  events,
+  control,
+  sensing,
+  operators,
+  variables,
+  json,
+  myBlocks,
+  comments
 };
 
 export default makeToolboxXML;

--- a/src/reducers/toolbox.js
+++ b/src/reducers/toolbox.js
@@ -2,7 +2,7 @@ const UPDATE_TOOLBOX = 'scratch-gui/toolbox/UPDATE_TOOLBOX';
 import makeToolboxXML from '../lib/make-toolbox-xml';
 
 const initialState = {
-    toolboxXML: makeToolboxXML(true)
+    toolboxXML: makeToolboxXML(null, true)
 };
 
 const reducer = function (state, action) {


### PR DESCRIPTION
Preferably merge https://github.com/Nitro-Bolt/scratch-gui/pull/52/ first as it will be conflicting.

Exposes makeToolboxXML in an event and in Scratch.gui. details were discussed on discord.
![image](https://github.com/user-attachments/assets/770793bd-2909-46c4-8072-745ecca8ad9b)
