### PR TITLE
Mistwarp theme compat

### DIFF
--- a/src/components/nb-custom-accent-modal/custom-accent-modal.jsx
+++ b/src/components/nb-custom-accent-modal/custom-accent-modal.jsx
@@ -8,6 +8,7 @@ import Box from '../box/box.jsx';
 import FancyCheckbox from '../tw-fancy-checkbox/checkbox.jsx';
 import FileInput from './file-input.jsx';
 import {gradientDataToCSS} from '../../lib/nb-gradient-to-css.js';
+import {isMistwarpTheme, convertMistwarpTheme} from '../../lib/themes/mistwarp-compat.js';
 
 const messages = defineMessages({
     title: {
@@ -398,6 +399,19 @@ const CustomAccentModal = props => {
                                             data = JSON.parse(await file.text());
                                         } catch {
                                             isValid = false;
+                                        }
+                                        if (isMistwarpTheme(data)) {
+                                            const converted = convertMistwarpTheme(data);
+                                            if (converted) {
+                                                data = {
+                                                    name: converted.accent.name || file.name.replace('.json', ''),
+                                                    primaryColor: converted.accent.primaryColor,
+                                                    secondaryColor: converted.accent.secondaryColor,
+                                                    tertiaryColor: converted.accent.tertiaryColor,
+                                                    gradient: converted.accent.gradient,
+                                                    isGradient: converted.accent.isGradient
+                                                };
+                                            }
                                         }
                                         const colorRegex = /^#[a-fA-F0-9]{6}$/;
                                         // eslint-disable-next-line max-len

--- a/src/lib/themes/mistwarp-compat.js
+++ b/src/lib/themes/mistwarp-compat.js
@@ -22,16 +22,52 @@ const convertMistwarpTheme = mistwarpData => {
     let gradient = null;
     const menuBarGradient = guiColors['menu-bar-background-image'];
     if (menuBarGradient && typeof menuBarGradient === 'string' && menuBarGradient.startsWith('linear-gradient')) {
-        const match = menuBarGradient.match(
-            /linear-gradient\((\d+)deg,\s*rgba?\([^)]+\)\s*(\d+)%,\s*rgba?\([^)]+\)\s*(\d+)%\)/
-        );
-        if (match) {
-            const direction = parseInt(match[1], 10);
-            const colors = [
-                {color: primaryColor, position: parseInt(match[2], 10)},
-                {color: tertiaryColor, position: parseInt(match[3], 10)}
-            ];
-            gradient = {direction, colors};
+        const directionMatch = menuBarGradient.match(/linear-gradient\((\d+)deg/);
+        
+        if (directionMatch) {
+            const direction = parseInt(directionMatch[1], 10);
+            const colorStopRegex = /(rgba?|hsla?)\([^)]+\)\s*(\d+%)?/g;
+            const colorMatches = [];
+            let match;
+            while ((match = colorStopRegex.exec(menuBarGradient)) !== null) {
+                colorMatches.push(match[0]);
+            }
+
+            if (colorMatches.length >= 2) {
+                const parseColor = colorStr => {
+                    const paramsMatch = colorStr.match(/\(([^)]+)\)/);
+                    if (!paramsMatch) return null;
+                    const params = paramsMatch[1].split(',').map(s => s.trim());
+                    
+                    const isRgb = colorStr.startsWith('rgb');
+                    const isRgba = colorStr.startsWith('rgba');
+                    
+                    if (isRgb || isRgba) {
+                        const r = parseInt(params[0], 10);
+                        const g = parseInt(params[1], 10);
+                        const b = parseInt(params[2], 10);
+                        const a = isRgba ? parseFloat(params[3]) : 1;
+                        const rStr = r.toString(16).padStart(2, '0');
+                        const gStr = g.toString(16).padStart(2, '0');
+                        const bStr = b.toString(16).padStart(2, '0');
+                        return {hex: `#${rStr}${gStr}${bStr}`, a};
+                    }
+                    return null;
+                };
+
+                const colors = colorMatches.map((colorStr, index) => {
+                    const positionMatch = colorStr.match(/(\d+)%$/);
+                    const position = positionMatch ?
+                        parseInt(positionMatch[1], 10) :
+                        Math.round((index / (colorMatches.length - 1)) * 100);
+                    const parsed = parseColor(colorStr);
+                    return parsed ? {color: parsed.hex, position} : null;
+                }).filter(c => c);
+
+                if (colors.length >= 2) {
+                    gradient = {direction, colors};
+                }
+            }
         }
     }
 

--- a/src/lib/themes/mistwarp-compat.js
+++ b/src/lib/themes/mistwarp-compat.js
@@ -1,0 +1,66 @@
+const isMistwarpTheme = data => {
+    if (!data || typeof data !== 'object') return false;
+    if (data.themes && Array.isArray(data.themes) && data.themes.length > 0) {
+        const theme = data.themes[0];
+        return !!(theme && theme.accent && theme.accent.guiColors && theme.accent.blockColors);
+    }
+    return false;
+};
+
+const convertMistwarpTheme = mistwarpData => {
+    if (!isMistwarpTheme(mistwarpData)) {
+        return null;
+    }
+
+    const theme = mistwarpData.themes[0];
+    const guiColors = theme.accent.guiColors;
+
+    const primaryColor = guiColors['motion-primary'];
+    const secondaryColor = guiColors['motion-tertiary'];
+    const tertiaryColor = guiColors['extensions-primary'];
+
+    let gradient = null;
+    const menuBarGradient = guiColors['menu-bar-background-image'];
+    if (menuBarGradient && typeof menuBarGradient === 'string' && menuBarGradient.startsWith('linear-gradient')) {
+        const match = menuBarGradient.match(
+            /linear-gradient\((\d+)deg,\s*rgba?\([^)]+\)\s*(\d+)%,\s*rgba?\([^)]+\)\s*(\d+)%\)/
+        );
+        if (match) {
+            const direction = parseInt(match[1], 10);
+            const colors = [
+                {color: primaryColor, position: parseInt(match[2], 10)},
+                {color: tertiaryColor, position: parseInt(match[3], 10)}
+            ];
+            gradient = {direction, colors};
+        }
+    }
+
+    const accent = {
+        name: theme.name,
+        primaryColor,
+        secondaryColor,
+        tertiaryColor,
+        gradient,
+        isGradient: !!gradient
+    };
+
+    const gui = theme.gui === 'dark' ? 'dark' : 'light';
+
+    let blocks = 'three';
+    if (theme.blocks === 'dark') {
+        blocks = 'dark';
+    } else if (theme.blocks === 'high-contrast') {
+        blocks = 'high-contrast';
+    }
+
+    return {
+        accent,
+        gui,
+        blocks
+    };
+};
+
+export {
+    isMistwarpTheme,
+    convertMistwarpTheme
+};


### PR DESCRIPTION
### Resolves

N/A

### Proposed Changes

This PR adds a basic compatibility layer to NitroBolt to allow it to load exported MistWarp themes

### Reason for Changes

Fun, plus this removes friction for people to move from MistWarp to NitroBolt, this is the inverse of how MistWarp supports NitroBolt themes.

### Side by sides

<img width="2304" height="1347" alt="Screenshot 2026-02-28 at 13 05 16" src="https://github.com/user-attachments/assets/4271c1ad-341d-4cae-b182-0be433f0e7f3" />

<img width="2304" height="1351" alt="Screenshot 2026-02-28 at 13 01 20" src="https://github.com/user-attachments/assets/628669a3-3d77-48dc-a6dc-6eb5491f2d79" />
